### PR TITLE
Decrease minimum twx version to 8.2.0

### DIFF
--- a/configfiles/metadata.xml
+++ b/configfiles/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Entities>
     <ExtensionPackages>
-        <ExtensionPackage dependsOn="" description="This extension provides various GIT capabilities that allow storing ThingWorx applications in a third party Git server" minimumThingWorxVersion="8.5.0" name="GitBackupExtension" packageVersion="3.0.0" vendor="ThingWorx Labs">
+        <ExtensionPackage dependsOn="" description="This extension provides various GIT capabilities that allow storing ThingWorx applications in a third party Git server" minimumThingWorxVersion="8.2.0" name="GitBackupExtension" packageVersion="3.0.1" vendor="ThingWorx Labs">
             <JarResources>
                 <FileResource description="" file="org.eclipse.jgit-5.4.0.201906121030-r.jar" type="JAR"/>
                 <FileResource description="" file="JavaEWAH-1.1.6.jar" type="JAR"/>

--- a/extension.properties
+++ b/extension.properties
@@ -1,8 +1,8 @@
 build_framework=ANT
 dependsOn=
 eclipse.preferences.version=1
-min_thingworx_version=8.5.0
-package_version=3.0.0
+min_thingworx_version=8.2.0
+package_version=3.0.1
 project_vendor=ThingWorx Labs
 sdk_location=C\:\\Users\\vrosu\\Downloads\\MED-61098-CD-085_F000_ThingWorx-Extension-SDK-8-5-0.zip
 twx_eclipse_plugin_version=7.2.0.201608021836


### PR DESCRIPTION
As mentioned in #4, the GitBackup extension is also used to migrate between thingworx versions, as well as in projects still using older and more stable versions of thingworx. 
This PR decreases the minimum thingworx version to 8.2.0. 

Tests have been run for compatibility against the following thingworx versions:
* 8.2.1-b140
* 8.3.0-b349
* 8.3.1-b441
* 8.4.0-b2013
* 8.4.4-b2319
